### PR TITLE
neural_style: make upstream changes to support pytorch 2.1.0

### DIFF
--- a/neural_style/neural_style.py
+++ b/neural_style/neural_style.py
@@ -35,7 +35,7 @@ def train(args):
         torch.cuda.manual_seed(args.seed)
 
     transform = transforms.Compose([
-        transforms.Scale(args.image_size),
+        transforms.Resize(args.image_size),
         transforms.CenterCrop(args.image_size),
         transforms.ToTensor(),
         transforms.Lambda(lambda x: x.mul(255))
@@ -100,8 +100,8 @@ def train(args):
             total_loss.backward()
             optimizer.step()
 
-            agg_content_loss += content_loss.data[0]
-            agg_style_loss += style_loss.data[0]
+            agg_content_loss += content_loss.data
+            agg_style_loss += style_loss.data
 
             if (batch_id + 1) % args.log_interval == 0:
                 mesg = "{}\tEpoch {}:\t[{}/{}]\tcontent: {:.6f}\tstyle: {:.6f}\ttotal: {:.6f}".format(


### PR DESCRIPTION
Changes are made to make the script fit for latest pytorch released

1. Switch from Scale to Resize as Scale is [deprecated](http://pytorch.org/vision/0.11/transforms.html#torchvision.transforms.Scale) in later versions of pytorch

2.  Removed Index of 0-dim tensor. [Source](https://github.com/NVIDIA/flownet2-pytorch/issues/113#issuecomment-450802359)